### PR TITLE
Add Explode iComponents feature and simplify null checks

### DIFF
--- a/Doyle Addin/DoyleAddin.csproj
+++ b/Doyle Addin/DoyleAddin.csproj
@@ -73,6 +73,7 @@
         <Compile Include="GlobalsHelpers.cs"/>
         <Compile Include="My Project\AssemblyInfo.cs"/>
         <Compile Include="My Project\SVGconvert.cs"/>
+        <Compile Include="Optional Features\ExplodeiComponents.cs"/>
         <Compile Include="Optional Features\ObsoletePrint.cs"/>
         <Compile Include="Options\UserControl.xaml.cs"/>
         <Compile Include="Prints\PDFToJPG.cs"/>
@@ -116,7 +117,12 @@
     </ItemGroup>
     <ItemGroup>
         <PackageReference Include="Autodesk.Inventor.Sdk" Version="1.0.3"/>
+        <PackageReference Include="ClosedXML" Version="0.104.2"/>
         <PackageReference Include="Docnet.Core" Version="2.7.0-alpha.1"/>
+        <PackageReference Include="Microsoft.CodeAnalysis.CSharp.CodeStyle" Version="5.0.0">
+            <PrivateAssets>all</PrivateAssets>
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageReference>
         <PackageReference Include="Ookii.Dialogs.Wpf" Version="5.0.1"/>
         <PackageReference Include="Svg" Version="3.4.7"/>
         <PackageReference Include="WPF-UI" Version="4.2.0"/>
@@ -128,5 +134,8 @@
         <Page Include="Options\Themes\DarkTheme.xaml"/>
         <Page Include="Options\Themes\LightTheme.xaml"/>
         <Page Include="Options\UserControl.xaml"/>
+    </ItemGroup>
+    <ItemGroup>
+        <EmbeddedResource Include="Resources\ExplodeiPart.svg"/>
     </ItemGroup>
 </Project>

--- a/Doyle Addin/My Project/SVGconvert.cs
+++ b/Doyle Addin/My Project/SVGconvert.cs
@@ -1,4 +1,4 @@
-﻿namespace DoyleAddin.My_Project;
+namespace DoyleAddin.My_Project;
 
 using System.Drawing;
 using System.Drawing.Drawing2D;
@@ -19,9 +19,9 @@ internal static class SVGconvert
 		var method = axHostType.GetMethod("GetIPictureDispFromPicture",
 			BindingFlags.Static | BindingFlags.NonPublic);
 
-		if (method == null) throw new InvalidOperationException("Cannot access GetIPictureDispFromPicture method");
-
-		return method.Invoke(null, new object[] { image });
+		return method == null
+			? throw new InvalidOperationException("Cannot access GetIPictureDispFromPicture method")
+			: method.Invoke(null, [image]);
 	}
 
 	// Find a group by "name" or "inkscape:label" attribute

--- a/Doyle Addin/Optional Features/ExplodeiComponents.cs
+++ b/Doyle Addin/Optional Features/ExplodeiComponents.cs
@@ -1,0 +1,603 @@
+﻿namespace DoyleAddin.Optional_Features;
+
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Runtime.InteropServices;
+using System.Windows.Forms;
+using ClosedXML.Excel;
+using Inventor;
+using IOFile = File;
+using IOPath = Path;
+
+/// <summary>
+///     Provides functionality to explode iPart and iAssembly factories into individual standard parts and assemblies
+/// </summary>
+public static class ExplodeiComponents
+{
+	/// <summary>
+	///     Main entry point to explode iPart/iAssembly into individual standard parts/assemblies
+	/// </summary>
+	public static void ExplodeiComponentsAction()
+	{
+		Debug.WriteLine("=== ExplodeiComponentsAction Started ===");
+
+		var activeDoc = ThisApplication.ActiveDocument;
+
+		switch (activeDoc)
+		{
+			case PartDocument partDoc:
+			{
+				Debug.WriteLine($"Active document: {partDoc.FullFileName}");
+				Debug.WriteLine($"Is iPart Factory: {partDoc.ComponentDefinition.IsiPartFactory}");
+
+				if (partDoc.ComponentDefinition.IsiPartFactory)
+				{
+					ExplodeFactory(partDoc);
+				}
+				else
+				{
+					Debug.WriteLine("Document is not an iPart factory");
+					MessageBox.Show("The active document is not an iPart factory.",
+						"Explode iComponents", MessageBoxButtons.OK, MessageBoxIcon.Information);
+				}
+
+				break;
+			}
+			case AssemblyDocument asmDoc:
+			{
+				Debug.WriteLine($"Active document: {asmDoc.FullFileName}");
+				Debug.WriteLine($"Is iAssembly Factory: {asmDoc.ComponentDefinition.IsiAssemblyFactory}");
+
+				if (asmDoc.ComponentDefinition.IsiAssemblyFactory)
+				{
+					ExplodeFactory(asmDoc);
+				}
+				else
+				{
+					Debug.WriteLine("Document is not an iAssembly factory");
+					MessageBox.Show("The active document is not an iAssembly factory.",
+						"Explode iComponents", MessageBoxButtons.OK, MessageBoxIcon.Information);
+				}
+
+				break;
+			}
+			default:
+				Debug.WriteLine("No active Part or Assembly document found");
+				MessageBox.Show(
+					"Please open an iPart or an iAssembly.",
+					"Explode iComponents", MessageBoxButtons.OK, MessageBoxIcon.Information);
+				break;
+		}
+
+		Debug.WriteLine("=== ExplodeiComponentsAction Finished ===");
+		ThisApplication.Documents.CloseAll(true);
+	}
+
+	/// <summary>
+	///     Explodes an iPart or iAssembly factory into individual standard components
+	/// </summary>
+	private static void ExplodeFactory(dynamic factoryDoc)
+	{
+		try
+		{
+			Debug.WriteLine("=== ExplodeFactory Started ===");
+
+			switch (factoryDoc)
+			{
+				case PartDocument partDoc:
+					ExplodeiPartFactory(partDoc);
+					break;
+
+				case AssemblyDocument asmDoc:
+					ExplodeiAssemblyFactory(asmDoc);
+					break;
+
+				default:
+					throw new ArgumentException("Unsupported document type.");
+			}
+		}
+		catch (Exception ex)
+		{
+			ThisApplication.Documents.CloseAll(true);
+			Debug.WriteLine($"ExplodeFactory failed: {ex}");
+			MessageBox.Show($"Error during component explosion: {ex.Message}",
+				"Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
+		}
+	}
+
+	// ===================================================================
+	// iPART – New refactored approach with working copies
+	// ===================================================================
+	private static void ExplodeiPartFactory(PartDocument factoryDoc)
+	{
+		try
+		{
+			Debug.WriteLine("=== Explode iPart Factory Started ===");
+
+			var factory = factoryDoc.ComponentDefinition.iPartFactory;
+
+			if (factory == null)
+			{
+				MessageBox.Show("Could not access the iPart factory.",
+					"Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
+				return;
+			}
+
+			var xlsxOutputDirectory = GetComponentDirectory((dynamic)factoryDoc);
+			var tempXlsxPath        = CreateExcelBackup(factory, xlsxOutputDirectory, "iPart Members");
+			Debug.WriteLine($"Excel backup created at: {tempXlsxPath}");
+
+			var processedCount = 0;
+			var totalCount     = factory.TableRows.Count;
+
+			// Process each member
+			for (var i = 1; i <= totalCount; i++)
+				try
+				{
+					Debug.WriteLine($"--- Processing iPart member {i} of {totalCount} ---");
+
+					factory = factoryDoc.ComponentDefinition.iPartFactory; // Refresh factory reference
+					if (factory == null)
+						throw new InvalidOperationException("Could not access iPart factory.");
+
+					var row = factory.TableRows[i];
+					factory.DefaultRow = row;
+					factoryDoc.Update();
+
+					var partNumber = GetPartNumber((dynamic)factoryDoc);
+					Debug.WriteLine($"Part number: {partNumber}");
+
+					// Get the original file path where this member would be generated
+					var originalPath = IOPath.Combine(GetComponentDirectory((dynamic)factoryDoc),
+						$"{partNumber}.ipt");
+					// Overwrite any existing target file
+					if (IOFile.Exists(originalPath))
+					{
+						Debug.WriteLine("Deleting existing target file...");
+						IOFile.Delete(originalPath);
+					}
+
+					var workingCopyPath =
+						IOPath.Combine(IOPath.GetTempPath(), $"iPart_WorkingCopy_{Guid.NewGuid():N}.ipt");
+					Debug.WriteLine($"Creating working copy: {workingCopyPath}");
+					factoryDoc.SaveAs(workingCopyPath, true);
+
+					dynamic workingDoc = (PartDocument)ThisApplication.Documents.Open(workingCopyPath, false);
+					workingDoc.Update();
+
+					// Set the part number iProperty to ensure it's retained
+					try
+					{
+						var designTrackingProps = workingDoc.PropertySets["Design Tracking Properties"];
+						designTrackingProps["Part Number"].Value = partNumber;
+						Debug.WriteLine($"Set Part Number iProperty to: {partNumber}");
+					}
+					catch (Exception ex)
+					{
+						Debug.WriteLine($"Failed to set Part Number iProperty: {ex.Message}");
+					}
+
+					try
+					{
+						ConvertToStandardComponent(workingDoc);
+
+						// Ensure the part number iProperty is set correctly after conversion
+						try
+						{
+							var designTrackingProps = workingDoc.PropertySets["Design Tracking Properties"];
+							designTrackingProps["Part Number"].Value = partNumber;
+							Debug.WriteLine($"Re-set Part Number iProperty to: {partNumber}");
+						}
+						catch (Exception ex)
+						{
+							Debug.WriteLine($"Failed to re-set Part Number iProperty: {ex.Message}");
+						}
+
+						Debug.WriteLine("Saving standard copy...");
+						SaveAsStandard(workingDoc, originalPath, "ipt");
+
+						processedCount++;
+
+						// Update progress
+						ThisApplication.StatusBarText =
+							$"Processed {processedCount} of {totalCount} members: {partNumber}";
+						Debug.WriteLine($"Member {i} processed successfully");
+					}
+					catch (InvalidOperationException ex)
+					{
+						Debug.WriteLine($"Error processing member {i}: {ex}");
+						MessageBox.Show(
+							$"Failed to convert iPart to standard component for member {i}:\n{ex.Message}",
+							"Conversion Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
+					}
+					catch (Exception ex)
+					{
+						Debug.WriteLine($"Unexpected error processing member {i}: {ex}");
+						MessageBox.Show($"Unexpected error processing member {i}:\n{ex.Message}",
+							"Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
+					}
+					finally
+					{
+						try
+						{
+							workingDoc.Close();
+						}
+						catch (Exception ex)
+						{
+							Debug.WriteLine($"Failed to close working copy document: {ex}");
+						}
+						finally
+						{
+							// Release the COM reference to prevent memory leaks
+							try
+							{
+								Marshal.ReleaseComObject(workingDoc);
+							}
+							catch (Exception ex)
+							{
+								Debug.WriteLine($"Failed to release COM object: {ex}");
+							}
+						}
+
+						try
+						{
+							if (IOFile.Exists(workingCopyPath))
+								IOFile.Delete(workingCopyPath);
+						}
+						catch (Exception ex)
+						{
+							Debug.WriteLine($"Failed to delete working copy file: {ex}");
+						}
+					}
+				}
+				catch (Exception ex)
+				{
+					Debug.WriteLine($"Error processing member {i}: {ex}");
+					MessageBox.Show($"Error processing member {i}: {ex.Message}",
+						"Processing Error", MessageBoxButtons.OK, MessageBoxIcon.Warning);
+				}
+
+			Debug.WriteLine($"=== Explode iPart Completed - Processed {processedCount} members ===");
+			MessageBox.Show(
+				$"Successfully exploded {processedCount} iParts into standard parts.\n\n" +
+				$"Table backup saved here:\n{xlsxOutputDirectory}",
+				"Complete", MessageBoxButtons.OK, MessageBoxIcon.Information);
+		}
+		catch (Exception ex)
+		{
+			Debug.WriteLine($"Explode iPart failed: {ex}");
+			MessageBox.Show($"Error during iPart explosion: {ex.Message}",
+				"Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
+		}
+	}
+
+	// ===================================================================
+	// iASSEMBLY – Simplified version (exactly what you said works great)
+	// ===================================================================
+	private static void ExplodeiAssemblyFactory(AssemblyDocument factoryDoc)
+	{
+		var factory = factoryDoc.ComponentDefinition.iAssemblyFactory;
+		ExplodeFactoryCoreSimplified(factoryDoc, factory, "iam");
+	}
+
+	private static void ExplodeFactoryCoreSimplified(dynamic factoryDoc, dynamic factory, string extension)
+	{
+		var totalCount = factory.TableRows.Count;
+
+		// Clear the cache directory before generating members
+		var cacheDir = factory.MemberCacheDir ?? IOPath.GetDirectoryName(factoryDoc.FullFileName) ?? string.Empty;
+		if (Directory.Exists(cacheDir))
+			foreach (var file in Directory.GetFiles(cacheDir))
+				IOFile.Delete(file);
+
+		// First, generate all members in the cache
+		for (var i = 1; i <= totalCount; i++)
+		{
+			var row = factory.TableRows[i];
+			factory.DefaultRow = row;
+			factoryDoc.Save();
+			factory.CreateMember(row);
+			Marshal.ReleaseComObject(row);
+		}
+
+		var memberFiles = Directory.GetFiles(cacheDir, $"*.{extension}");
+
+		foreach (var cacheFilePath in memberFiles)
+		{
+			var fileName = IOPath.GetFileName(cacheFilePath);
+			var destinationPath =
+				IOPath.Combine(IOPath.GetDirectoryName(factoryDoc.FullFileName) ?? string.Empty, fileName);
+
+			// Open the member from the cache
+			var memberDoc = ThisApplication.Documents.Open(cacheFilePath, false);
+
+			// Break the link to make it a standard component
+			BreakFactoryLink(memberDoc);
+
+			// Save and move to the permanent location
+			memberDoc.Save();
+			memberDoc.Close();
+			ThisApplication.Documents.CloseAll(true);
+			Marshal.ReleaseComObject(memberDoc);
+
+			if (IOFile.Exists(destinationPath)) IOFile.Delete(destinationPath);
+			if (destinationPath != null) IOFile.Copy(cacheFilePath, destinationPath);
+		}
+
+		Debug.WriteLine($"=== Explode iAssembly Completed - Processed {memberFiles.Length} members ===");
+		MessageBox.Show(
+			$"Successfully exploded {memberFiles.Length} iAssemblies into standard assemblies.",
+			"Complete", MessageBoxButtons.OK, MessageBoxIcon.Information);
+		ThisApplication.Documents.CloseAll(true);
+	}
+
+	private static void BreakFactoryLink(dynamic memberDoc)
+	{
+		switch (memberDoc)
+		{
+			case PartDocument pDoc when pDoc.ComponentDefinition.IsiPartMember:
+				pDoc.ComponentDefinition.iPartMember.BreakLinkToFactory();
+				break;
+			case AssemblyDocument aDoc when aDoc.ComponentDefinition.IsiAssemblyMember:
+				aDoc.ComponentDefinition.iAssemblyMember.BreakLinkToFactory();
+				break;
+		}
+	}
+
+	// ====================== Excel Backup and Helper Methods ======================
+
+	/// <summary>
+	///     Creates an Excel backup of the iComponent member table
+	/// </summary>
+	private static string CreateExcelBackup(dynamic factory, string outputDirectory, string sheetName)
+	{
+		if (string.IsNullOrWhiteSpace(outputDirectory)) return string.Empty;
+
+		var tempPath = IOPath.Combine(outputDirectory, $"iComponent_Backup_{DateTime.Now:yyyyMMdd_HHmmss}.xlsx");
+
+		try
+		{
+			if (!Directory.Exists(outputDirectory))
+				Directory.CreateDirectory(outputDirectory);
+
+			using var workbook  = new XLWorkbook();
+			var       worksheet = workbook.Worksheets.Add(sheetName);
+
+			var tableColumns = factory.TableColumns;
+			var tableRows    = factory.TableRows;
+			int columnCount  = tableColumns.Count;
+			int rowCount     = tableRows.Count;
+
+			Debug.WriteLine($"Creating Excel backup: {columnCount} columns, {rowCount} rows");
+
+			// Write headers (1-based indexing for Inventor COM collections)
+			for (var col = 1; col <= columnCount; col++)
+			{
+				var column = tableColumns[col];
+				worksheet.Cell(1, col).Value = column.DisplayHeading ?? $"Column_{col}";
+			}
+
+			// Style headers
+			var headerRow = worksheet.Range(1, 1, 1, columnCount);
+			headerRow.Style.Font.Bold            = true;
+			headerRow.Style.Fill.BackgroundColor = XLColor.LightGray;
+
+			// Write data for each row
+			for (var row = 1; row <= rowCount; row++)
+			{
+				var tableRow = tableRows[row];
+				for (var col = 1; col <= columnCount; col++)
+				{
+					var cellValue = tableRow[col].Value;
+					if (cellValue != null)
+						worksheet.Cell(row + 1, col).Value = cellValue.ToString();
+				}
+			}
+
+			worksheet.Columns().AdjustToContents();
+			workbook.SaveAs(tempPath);
+			Debug.WriteLine($"Excel backup saved: {tempPath}");
+			return tempPath;
+		}
+		catch (Exception ex)
+		{
+			Debug.WriteLine($"CreateExcelBackup exception: {ex}");
+			MessageBox.Show($"Warning: Could not create Excel backup: {ex.Message}",
+				"Backup Warning", MessageBoxButtons.OK, MessageBoxIcon.Warning);
+			return tempPath;
+		}
+	}
+
+	// ====================== Remaining original helper methods (unchanged) ======================
+
+	private static string GetComponentDirectory(Document factoryDoc)
+	{
+		var fullFileName = factoryDoc.FullFileName ?? string.Empty;
+		var factoryDir   = IOPath.GetDirectoryName(fullFileName);
+		var factoryBase  = IOPath.GetFileNameWithoutExtension(fullFileName);
+		return IOPath.Combine(factoryDir ?? string.Empty, factoryBase);
+	}
+
+	/// <summary>
+	///     Saves the document as a standard component with the specified filename
+	/// </summary>
+	private static void SaveAsStandard(dynamic doc, string filePath, string extension)
+	{
+		Debug.WriteLine($"SaveAsStandard called with path: {filePath}");
+
+		// Ensure directory exists
+		var directory = IOPath.GetDirectoryName(filePath);
+		Debug.WriteLine($"Target directory: {directory}");
+
+		if (!string.IsNullOrEmpty(directory) && !Directory.Exists(directory))
+		{
+			Debug.WriteLine($"Creating directory: {directory}");
+			Directory.CreateDirectory(directory);
+		}
+
+		// Save as copy using temp file to avoid SaveAs issues
+		Debug.WriteLine("Saving document to " + filePath);
+		var tempFilePath = IOPath.Combine(IOPath.GetTempPath(), $"Export_{Guid.NewGuid():N}.{extension}");
+		Debug.WriteLine("Saving document to temp path " + tempFilePath);
+		doc.SaveAs(tempFilePath, true);
+		Debug.WriteLine("Temp save successful; copying to target");
+		IOFile.Copy(tempFilePath, filePath, true);
+		IOFile.Delete(tempFilePath);
+		Debug.WriteLine("Copy to target successful");
+	}
+
+	private static void ConvertToStandardComponent(Document doc)
+	{
+		Debug.WriteLine("ConvertToStandardComponent called");
+
+		switch (doc)
+		{
+			case PartDocument partDoc:
+				Debug.WriteLine($"Is iPart Factory before conversion: {partDoc.ComponentDefinition.IsiPartFactory}");
+				if (partDoc.ComponentDefinition.IsiPartFactory)
+					try
+					{
+						// Update document to ensure consistent state
+						partDoc.Update();
+
+						// Save the document before deleting the factory
+						partDoc.Save();
+
+						// Proceed directly to factory deletion
+						Debug.WriteLine("Attempting to delete iPart factory...");
+						partDoc.ComponentDefinition.iPartFactory.Delete();
+						Debug.WriteLine("iPart factory deleted");
+
+						// Try to update after deletion
+						try
+						{
+							partDoc.Update();
+							Debug.WriteLine("Document updated after factory deletion");
+						}
+						catch (COMException updateEx)
+						{
+							Debug.WriteLine(
+								$"Post-deletion update failed, but factory was deleted: {updateEx.Message}");
+						}
+					}
+					catch (COMException ex)
+					{
+						Debug.WriteLine($"COM Exception deleting iPart factory: {ex.Message}");
+						throw new InvalidOperationException($"Failed to delete iPart factory: {ex.Message}", ex);
+					}
+				else
+					Debug.WriteLine("Document is not an iPart factory - nothing to delete");
+
+				break;
+
+			case AssemblyDocument asmDoc:
+				Debug.WriteLine(
+					$"Is iAssembly Factory before conversion: {asmDoc.ComponentDefinition.IsiAssemblyFactory}");
+				if (asmDoc.ComponentDefinition.IsiAssemblyFactory)
+					try
+					{
+						// Update document to ensure consistent state
+						asmDoc.Update();
+
+						// Save the document before deleting the factory
+						asmDoc.Save();
+
+						// Suppress all constraints to prevent issues during factory deletion
+						Debug.WriteLine("Suppressing all assembly constraints...");
+						foreach (AssemblyConstraint constraint in asmDoc.ComponentDefinition.Constraints)
+							try
+							{
+								constraint.Suppressed = true;
+							}
+							catch (Exception ex)
+							{
+								Debug.WriteLine($"Failed to suppress constraint {constraint.Name}: {ex.Message}");
+							}
+
+						Debug.WriteLine("All constraints suppressed");
+
+						// Update the document to ensure consistency after suppressing constraints
+						try
+						{
+							asmDoc.Update();
+							Debug.WriteLine("Document updated after suppressing constraints");
+						}
+						catch (Exception ex)
+						{
+							Debug.WriteLine($"Failed to update document after suppressing constraints: {ex.Message}");
+						}
+
+						// Collect excluded occurrences before deleting factory
+						var suppressedOccurrences = new List<ComponentOccurrence>();
+						foreach (var occ in asmDoc.ComponentDefinition.Occurrences.Cast<ComponentOccurrence>()
+						                          .Where(occ => occ.Excluded))
+						{
+							suppressedOccurrences.Add(occ);
+							Debug.WriteLine($"Collected excluded occurrence: {occ.Name}");
+						}
+
+						Debug.WriteLine($"Collected {suppressedOccurrences.Count} excluded occurrences");
+
+						// Delete the collected excluded occurrences to allow factory deletion
+						Debug.WriteLine("Deleting collected excluded occurrences...");
+						if (suppressedOccurrences.Count > 0)
+							foreach (var occ in suppressedOccurrences)
+								try
+								{
+									Debug.WriteLine($"Attempting to delete occurrence: {occ.Name}");
+									occ.Delete();
+									Debug.WriteLine($"Deleted excluded occurrence: {occ.Name}");
+								}
+								catch (Exception ex)
+								{
+									Debug.WriteLine($"Failed to delete excluded occurrence: {ex.Message}");
+								}
+
+						Debug.WriteLine("Deletion of excluded occurrences complete");
+
+						// Proceed directly to factory deletion
+						Debug.WriteLine("Attempting to delete iAssembly factory...");
+						asmDoc.ComponentDefinition.iAssemblyFactory.Delete();
+						Debug.WriteLine("iAssembly factory deleted");
+					}
+					catch (COMException ex)
+					{
+						Debug.WriteLine($"COM Exception deleting iAssembly factory: {ex.Message}");
+						throw new InvalidOperationException($"Failed to delete iAssembly factory: {ex.Message}", ex);
+					}
+				else
+					Debug.WriteLine("Document is not an iAssembly factory - nothing to delete");
+
+				break;
+
+			default:
+				Debug.WriteLine($"Unsupported document type: {doc.GetType().Name}");
+				break;
+		}
+	}
+
+	private static string GetPartNumber(Document doc)
+	{
+		try
+		{
+			var designTrackingProps = doc.PropertySets["Design Tracking Properties"];
+			var raw                 = designTrackingProps["Part Number"]?.Value?.ToString() ?? string.Empty;
+			var sanitized           = SanitizeFileName(raw);
+			return !string.IsNullOrWhiteSpace(sanitized)
+				? sanitized
+				: SanitizeFileName(IOPath.GetFileNameWithoutExtension(doc.FullFileName ?? string.Empty));
+		}
+		catch
+		{
+			return SanitizeFileName(IOPath.GetFileNameWithoutExtension(doc.FullFileName ?? string.Empty)) ?? "Member";
+		}
+	}
+
+	private static string SanitizeFileName(string value)
+	{
+		if (string.IsNullOrWhiteSpace(value)) return string.Empty;
+		value = IOPath.GetInvalidFileNameChars().Aggregate(value, (current, c) => current.Replace(c, '_'));
+		return value.Trim();
+	}
+}

--- a/Doyle Addin/Options/UserControl.xaml
+++ b/Doyle Addin/Options/UserControl.xaml
@@ -11,7 +11,8 @@
     FontFamily="Tahoma"
     WindowStartupLocation="CenterScreen"
     Loaded="UserOptionsWindow_Loaded" WindowStyle="None" AllowsTransparency="True" SnapsToDevicePixels="True"
-    ResizeMode="NoResize" ShowInTaskbar="False" SizeToContent="WidthAndHeight" Topmost="True" Background="Transparent">
+    ResizeMode="NoResize" ShowInTaskbar="False" SizeToContent="WidthAndHeight" Topmost="True" Background="Transparent"
+    d:DataContext="{d:DesignInstance }">
 
     <Window.Resources>
         <!-- Theme ResourceDictionaries are external (Options/Themes/*.xaml) and are merged at runtime by code. -->
@@ -89,14 +90,14 @@
         </Style>
     </Window.Resources>
 
-    <Border x:Name="MainWindowBorder"
-            Background="{DynamicResource WindowBackgroundBrush}"
-            CornerRadius="5"
-            BorderBrush="{DynamicResource BorderBrush}"
-            BorderThickness="4"
-            Padding="16" UseLayoutRounding="True" ClipToBounds="True"
-            ScrollViewer.VerticalScrollBarVisibility="Disabled"
-            Width="480" Height="208" IsEnabled="True">
+    <Border
+        Background="{DynamicResource WindowBackgroundBrush}"
+        CornerRadius="5"
+        BorderBrush="{DynamicResource BorderBrush}"
+        BorderThickness="4"
+        Padding="16" UseLayoutRounding="True" ClipToBounds="True"
+        ScrollViewer.VerticalScrollBarVisibility="Disabled"
+        Width="480" Height="208" IsEnabled="True">
 
         <Grid Margin="0,0,0,-10">
             <Grid.RowDefinitions>
@@ -145,52 +146,106 @@
             </Grid>
 
             <!-- Checkbox -->
-            <CheckBox x:Name="ChkObsoletePrint" FontFamily="Segoe UI"
-                      FontSize="12"
-                      Grid.Row="2" Content="Enable Obsolete Print"
-                      HorizontalAlignment="Left"
-                      Background="{DynamicResource ControlBackgroundBrush}"
-                      BorderBrush="{DynamicResource TextBoxBorderBrush}"
-                      Margin="0,0,0,0" VerticalAlignment="Center"
-                      IsChecked="{Binding EnableObsoletePrint, Mode=TwoWay}"
-                      Foreground="{DynamicResource ControlForegroundBrush}">
-                <CheckBox.Style>
-                    <Style TargetType="{x:Type CheckBox}">
-                        <Setter Property="Template">
-                            <Setter.Value>
-                                <ControlTemplate TargetType="{x:Type CheckBox}">
-                                    <StackPanel Orientation="Horizontal">
-                                        <Border Width="16" Height="16" Background="{TemplateBinding Background}"
-                                                BorderBrush="{TemplateBinding BorderBrush}" BorderThickness="1"
-                                                CornerRadius="2" Margin="0,0,8,0">
-                                            <Path x:Name="CheckMark" Visibility="Collapsed" Data="M2,8 L6,12 L14,2"
-                                                  Stroke="{TemplateBinding Foreground}" StrokeThickness="2"
-                                                  StrokeLineJoin="Round"
-                                                  StrokeStartLineCap="Round" StrokeEndLineCap="Round" />
-                                        </Border>
-                                        <ContentPresenter VerticalAlignment="Center" RecognizesAccessKey="True" />
-                                    </StackPanel>
-                                    <ControlTemplate.Triggers>
-                                        <Trigger Property="IsChecked" Value="True">
-                                            <Setter TargetName="CheckMark" Property="Visibility" Value="Visible" />
-                                        </Trigger>
-                                    </ControlTemplate.Triggers>
-                                </ControlTemplate>
-                            </Setter.Value>
-                        </Setter>
-                    </Style>
-                </CheckBox.Style>
-            </CheckBox>
-            <!-- Information Message -->
-            <Label x:Name="FutureMsg"
-                   FontFamily="Segoe UI"
-                   Grid.Row="2"
-                   Content="More options planned for the future"
-                   Background="Transparent"
-                   Foreground="{DynamicResource InfoForegroundBrush}"
-                   BorderThickness="0"
-                   FontSize="13" Margin="162,0,6,6" d:LayoutOverrides="Height" VerticalAlignment="Center"
-                   HorizontalAlignment="Center" />
+            <Grid Grid.Row="2">
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="Auto" />
+                    <ColumnDefinition Width="*" />
+                </Grid.ColumnDefinitions>
+
+                <StackPanel Grid.Column="0" Orientation="Vertical" VerticalAlignment="Center">
+                    <CheckBox x:Name="ChkObsoletePrint" FontFamily="Segoe UI"
+                              FontSize="12"
+                              Content="Enable Obsolete Print"
+                              HorizontalAlignment="Left"
+                              Background="{DynamicResource ControlBackgroundBrush}"
+                              BorderBrush="{DynamicResource TextBoxBorderBrush}"
+                              Margin="0,0,0,2" VerticalAlignment="Center"
+                              IsChecked="{Binding EnableObsoletePrint, Mode=TwoWay}"
+                              Foreground="{DynamicResource ControlForegroundBrush}">
+                        <CheckBox.Style>
+                            <Style TargetType="{x:Type CheckBox}">
+                                <Setter Property="Template">
+                                    <Setter.Value>
+                                        <ControlTemplate TargetType="{x:Type CheckBox}">
+                                            <StackPanel Orientation="Horizontal">
+                                                <Border Width="16" Height="16"
+                                                        Background="{TemplateBinding Background}"
+                                                        BorderBrush="{TemplateBinding BorderBrush}" BorderThickness="1"
+                                                        CornerRadius="2" Margin="0,0,8,0">
+                                                    <Path x:Name="CheckMark" Visibility="Collapsed"
+                                                          Data="M2,8 L6,12 L14,2"
+                                                          Stroke="{TemplateBinding Foreground}" StrokeThickness="2"
+                                                          StrokeLineJoin="Round"
+                                                          StrokeStartLineCap="Round" StrokeEndLineCap="Round" />
+                                                </Border>
+                                                <ContentPresenter VerticalAlignment="Center" RecognizesAccessKey="True" />
+                                            </StackPanel>
+                                            <ControlTemplate.Triggers>
+                                                <Trigger Property="IsChecked" Value="True">
+                                                    <Setter TargetName="CheckMark" Property="Visibility"
+                                                            Value="Visible" />
+                                                </Trigger>
+                                            </ControlTemplate.Triggers>
+                                        </ControlTemplate>
+                                    </Setter.Value>
+                                </Setter>
+                            </Style>
+                        </CheckBox.Style>
+                    </CheckBox>
+
+                    <CheckBox FontFamily="Segoe UI"
+                              FontSize="12"
+                              Content="Enable Explode iComponents"
+                              HorizontalAlignment="Left"
+                              Background="{DynamicResource ControlBackgroundBrush}"
+                              BorderBrush="{DynamicResource TextBoxBorderBrush}"
+                              Margin="0,2,0,0" VerticalAlignment="Center"
+                              IsChecked="{Binding EnableExplodeiComponents, Mode=TwoWay}"
+                              Foreground="{DynamicResource ControlForegroundBrush}">
+                        <CheckBox.Style>
+                            <Style TargetType="{x:Type CheckBox}">
+                                <Setter Property="Template">
+                                    <Setter.Value>
+                                        <ControlTemplate TargetType="{x:Type CheckBox}">
+                                            <StackPanel Orientation="Horizontal">
+                                                <Border Width="16" Height="16"
+                                                        Background="{TemplateBinding Background}"
+                                                        BorderBrush="{TemplateBinding BorderBrush}" BorderThickness="1"
+                                                        CornerRadius="2" Margin="0,0,8,0">
+                                                    <Path x:Name="CheckMark" Visibility="Collapsed"
+                                                          Data="M2,8 L6,12 L14,2"
+                                                          Stroke="{TemplateBinding Foreground}" StrokeThickness="2"
+                                                          StrokeLineJoin="Round"
+                                                          StrokeStartLineCap="Round" StrokeEndLineCap="Round" />
+                                                </Border>
+                                                <ContentPresenter VerticalAlignment="Center" RecognizesAccessKey="True" />
+                                            </StackPanel>
+                                            <ControlTemplate.Triggers>
+                                                <Trigger Property="IsChecked" Value="True">
+                                                    <Setter TargetName="CheckMark" Property="Visibility"
+                                                            Value="Visible" />
+                                                </Trigger>
+                                            </ControlTemplate.Triggers>
+                                        </ControlTemplate>
+                                    </Setter.Value>
+                                </Setter>
+                            </Style>
+                        </CheckBox.Style>
+                    </CheckBox>
+                </StackPanel>
+
+                <!-- Information Message -->
+                <Label x:Name="FutureMsg"
+                       FontFamily="Segoe UI"
+                       Grid.Column="1"
+                       Content="More options planned for the future"
+                       Background="Transparent"
+                       Foreground="{DynamicResource InfoForegroundBrush}"
+                       BorderThickness="0"
+                       FontSize="13" Margin="12,0,6,6" d:LayoutOverrides="Height" VerticalAlignment="Center"
+                       HorizontalAlignment="Center" />
+            </Grid>
+
             <Grid Grid.Row="3" Margin="0,24,0,-16" HorizontalAlignment="Center">
                 <Grid.ColumnDefinitions>
                     <ColumnDefinition Width="*" />

--- a/Doyle Addin/Options/UserOptions.cs
+++ b/Doyle Addin/Options/UserOptions.cs
@@ -60,6 +60,23 @@ public class UserOptions : INotifyPropertyChanged
 	} = false;
 
 	/// <summary>
+	///     Specifies whether the "Explode iComponents" functionality is enabled in the application.
+	///     When set to true, the related options and buttons for exploding iComponents are made
+	///     available in the user interface. This property is intended for scenarios where users
+	///     need to manually manipulate iComponents within their designs.
+	/// </summary>
+	public bool EnableExplodeiComponents
+	{
+		get;
+		init
+		{
+			if (value == field) return;
+			field = value;
+			OnPropertyChanged(nameof(EnableExplodeiComponents));
+		}
+	} = false;
+
+	/// <summary>
 	///     Raised when a property value changes; used by WPF data binding (INotifyPropertyChanged).
 	/// </summary>
 	public event PropertyChangedEventHandler PropertyChanged;

--- a/Doyle Addin/Resources/ExplodeiPart.svg
+++ b/Doyle Addin/Resources/ExplodeiPart.svg
@@ -1,0 +1,114 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+        xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+        xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+        xmlns:xlink="http://www.w3.org/1999/xlink"
+        version="1.1"
+        id="svg1"
+        width="32"
+        height="32"
+        viewBox="0 0 32 32"
+        sodipodi:docname="ExplodeiPart.svg"
+        inkscape:version="1.4.3 (0d15f75, 2025-12-25)"
+        xml:space="preserve"
+        xmlns="http://www.w3.org/2000/svg"><sodipodi:namedview
+   id="namedview1"
+   pagecolor="#505050"
+   bordercolor="#eeeeee"
+   borderopacity="1"
+   inkscape:showpageshadow="0"
+   inkscape:pageopacity="0"
+   inkscape:pagecheckerboard="0"
+   inkscape:deskcolor="#505050"
+   showgrid="true"
+   inkscape:zoom="11.313709"
+   inkscape:cx="12.065009"
+   inkscape:cy="19.843184"
+   inkscape:window-width="1920"
+   inkscape:window-height="1009"
+   inkscape:window-x="-8"
+   inkscape:window-y="-8"
+   inkscape:window-maximized="1"
+   inkscape:current-layer="g1"><inkscape:grid
+     id="grid116"
+     units="px"
+     originx="0"
+     originy="0"
+     spacingx="1"
+     spacingy="1"
+     empcolor="#0099e5"
+     empopacity="0.30196078"
+     color="#0099e5"
+     opacity="0.14901961"
+     empspacing="5"
+     dotted="false"
+     gridanglex="30"
+     gridanglez="30"
+     visible="true" /></sodipodi:namedview>
+    <defs
+            id="defs1"><inkscape:path-effect
+     effect="spiro"
+     id="path-effect14"
+     is_visible="true"
+     lpeversion="1" /></defs>
+    <g
+            inkscape:groupmode="layer"
+            inkscape:label="Light"
+            id="g1"
+            style="display:inline"
+            transform="matrix(0.125,0,0,0.125,-32,0)">
+        <path
+                d="m 256,0 v 192 h 120 v -8 H 264 V 8 h 176 v 112 h 8 V 0 Z"
+                style="display:inline;fill:#666666;stroke-width:0.148841;stroke-miterlimit:21.5;paint-order:markers stroke fill"
+                id="path20"/>
+        <path
+                d="m 376,184 v -16 h 48 v -48 h 16 V 8 H 264 v 176 z"
+                style="display:inline;fill:#f3f3f3;stroke-width:0.15385;stroke-miterlimit:21.5;paint-order:markers stroke fill"
+                id="path21"/>
+        <path
+                id="rect21"
+                style="fill:#666666;fill-opacity:1;stroke-width:0.133318;stroke-miterlimit:21.5;paint-order:markers stroke fill"
+                d="m 352,24 a 16,16 0 0 0 -16,16 16,16 0 0 0 16,16 16,16 0 0 0 16,-16 16,16 0 0 0 -16,-16 z m -32,48 v 16.25 h 16 V 152 h -16 v 16 h 64 V 152 H 368 V 88 72 Z"/>
+        <path
+                id="rect23"
+                style="fill:#b22424;fill-opacity:1;stroke:#a02020;stroke-width:16;stroke-miterlimit:21.5;stroke-dasharray:none;stroke-opacity:1;paint-order:markers stroke fill"
+                d="M 481.94113,146.74517 448,180.68629 l -33.94113,-33.94112 -11.49048,11.49048 33.94112,33.94113 -33.76434,33.76435 11.3137,11.3137 33.76435,-33.76434 33.94113,33.94112 11.49048,-11.49048 L 459.31371,192 493.25483,158.05887 Z"/>
+        <image
+                width="256"
+                height="256"
+                preserveAspectRatio="none"
+                xlink:href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAYAAABzenr0AAAABHNCSVQICAgIfAhkiAAAAQlJREFU&#10;WIXtlrENgzAQRT+RCxo3TMA0tsQUqViAObyAK6aIBNNkAmoXlkiFRCJsH4KLKXiV5TvJn7vj20Xb&#10;tjMYsdYWsbgAAGMMy+Fd1yVzHiwn70BQE4dhwDiOAAClFLTWpwggV2A5/Hf9NwFckAUopTbXRyHP&#10;gNb6tL6vyd6CZAVC//JZ3pG9AkkBxhg2pyQJ4OYWQPaBPUgpo1cwuwAAqPvm653xfr42RbG2QFQl&#10;RFVGc64/AyEnXPaPesT1KxD7QillYa3lFZDid9r35gmA9nqNkZr0UNxPDmTDCFH3zZwSEMJP7hwj&#10;8pPb3F+EheIAjlcgxLoyfnJ5nJDCLSC7ALbrGIhP/8IHNfBE/voggxEAAAAASUVORK5CYII=&#10;"
+                id="image1-5"
+                x="256"
+                y="0"
+                style="display:none;opacity:0;image-rendering:pixelated"/></g>
+    <g
+            inkscape:groupmode="layer"
+            inkscape:label="Dark"
+            id="g4"
+            style="display:inline"
+            transform="matrix(0.125,0,0,0.125,32,0)">
+        <path
+                d="m -256,0 v 192 h 120 v -24 h 48 v -48 h 24 V 0 Z"
+                style="display:inline;fill:#d9d9d9;fill-opacity:1;stroke-width:0.506493;stroke-miterlimit:21.5;paint-order:markers stroke fill"
+                id="path3"/>
+        <path
+                id="path4"
+                style="display:inline;fill:#666666;fill-opacity:1;stroke-width:0.0980424;stroke-miterlimit:21.5;paint-order:markers stroke fill"
+                d="m -160,24 a 16,16 0 0 0 -16,16 16,16 0 0 0 16,16 16,16 0 0 0 16,-16 16,16 0 0 0 -16,-16 z m -32,48 v 16 h 16 v 64 h -16 v 15.75 h 64 V 152 h -16 V 72 h -32 z"/>
+        <path
+                id="path15"
+                style="display:inline;fill:#ff0000;stroke-width:0.145718;stroke-miterlimit:21.5;paint-order:markers stroke fill"
+                d="m -127.99316,176.00171 v 31.99658 h 47.994869 v 47.99487 h 31.996582 V 207.99829 H -0.0068363 V 176.00171 H -48.001709 v -47.99487 h -31.996582 v 47.99487 z"
+                transform="rotate(45,-64.00001,192)"/>
+        <image
+                width="256"
+                height="256"
+                preserveAspectRatio="none"
+                xlink:href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAYAAABzenr0AAAABHNCSVQICAgIfAhkiAAAALxJREFU&#10;WIXtlcENwyAMRT9VdmEGZ5yu4FMn6IkVOg7MwDTtKYdGKJiAa0XlnyxA8sPYH5dzfkNR3nt3tH/T&#10;TC6ROcAiPRhjREoJAEBEWNd1CIC4AlvyffwzAC2JAYioGPfK/f0YVqcghFBcZ+YhAOYVqAIw87Db&#10;ngLQ1gQQ/wUtqs2+OgAA3PPzy+Be/lGEMn8Cc4DTTrit93qEeQW6fsOjbpc2YTfAPlGrzJ9gaTEN&#10;DZlXQO320wknwGUAPoxeNk5/yzWcAAAAAElFTkSuQmCC&#10;"
+                id="image1"
+                x="-256"
+                y="0"
+                style="display:none;opacity:0;image-rendering:pixelated"/></g></svg>

--- a/Doyle Addin/StandardAddInServer.cs
+++ b/Doyle Addin/StandardAddInServer.cs
@@ -26,10 +26,10 @@ public class StandardAddInServer : ApplicationAddInServer
 	private const string TabAnnotateId = "id_TabAnnotate";
 	private const string printupdate = "printUpdate";
 	private const string dxfupdate = "dxfUpdate";
-	private const string geniusprops = "geniusProps";
 	private const string drawing = "Drawing";
 	private const string obsoleteprint = "ObsoletePrint";
 	private const string addIns = "Add-Ins";
+	private const string explodeicomponents = "explodeiComponents";
 
 	private static readonly string[] SheetMetalManageUnfold = ["id_PanelP_SheetMetalManageUnfold"];
 	private static readonly string[] ToolsOptions = ["id_PanelP_ToolsOptions", addIns];
@@ -37,9 +37,13 @@ public class StandardAddInServer : ApplicationAddInServer
 	private static readonly string[] Item4Array2 = ["id_PanelP_ToolsOptions"];
 	private static readonly string[] FlatPatternExit = ["id_PanelP_FlatPatternExit"];
 	private static readonly string[] AnnotateRevision = ["id_PanelD_AnnotateRevision"];
+	private static readonly string[] ManagePanels = ["id_PanelP_Manage", "id_PanelA_Manage", addIns];
+
+	private static readonly string[] stringArray = ["Part", "Assembly"];
 
 	// Event handler delegates to ensure proper unsubscription
 	private readonly ButtonDefinitionSink_OnExecuteEventHandler _dxfUpdateHandler;
+	private readonly ButtonDefinitionSink_OnExecuteEventHandler _explodeiComponentsHandler;
 	private readonly ButtonDefinitionSink_OnExecuteEventHandler _obsoleteButtonHandler;
 	private readonly ButtonDefinitionSink_OnExecuteEventHandler _optionsButtonHandler;
 	private readonly ButtonDefinitionSink_OnExecuteEventHandler _printUpdateHandler;
@@ -47,8 +51,6 @@ public class StandardAddInServer : ApplicationAddInServer
 
 	// Instance field to store the Inventor application reference
 	private Application _application;
-
-	// New Genius Properties button definition and property
 
 	private UserInterfaceEvents uiEvents;
 
@@ -67,6 +69,7 @@ public class StandardAddInServer : ApplicationAddInServer
 		_printUpdateHandler                  = _ => PrintUpdate_OnExecute();
 		_optionsButtonHandler                = _ => OptionsButton_OnExecute();
 		_obsoleteButtonHandler               = _ => ObsoleteButton_OnExecute();
+		_explodeiComponentsHandler           = _ => ExplodeiComponents_OnExecute();
 		_uiEventsResetRibbonInterfaceHandler = UiEvents_OnResetRibbonInterface;
 	}
 
@@ -126,6 +129,20 @@ public class StandardAddInServer : ApplicationAddInServer
 		}
 	}
 
+	private ButtonDefinition ExplodeiComponentsButton
+	{
+		[MethodImpl(MethodImplOptions.Synchronized)]
+		get;
+		[MethodImpl(MethodImplOptions.Synchronized)]
+		set
+		{
+			field?.OnExecute -= _explodeiComponentsHandler;
+
+			field            =  value;
+			field?.OnExecute += _explodeiComponentsHandler;
+		}
+	}
+
 	// Inventor calls this method when it loads the AddIn. The AddInSiteObject provides access 
 	// To the Inventor Application object. The FirstTime flag indicates if the AddIn is loaded for
 	// The first time. However, with the introduction of the ribbon, this argument is always true.
@@ -179,8 +196,8 @@ public class StandardAddInServer : ApplicationAddInServer
 						},
 						new
 						{
-							Name         = "Genius Properties", Icon = "DoyleAddin.Resources.SettingsIcon.svg",
-							InternalName = geniusprops
+							Name         = "Explode iComponents", Icon = "DoyleAddin.Resources.ExplodeiPart.svg",
+							InternalName = explodeicomponents
 						}
 					};
 
@@ -231,6 +248,14 @@ public class StandardAddInServer : ApplicationAddInServer
 							{
 								ObsoleteButton = controlDefs.AddButtonDefinition("Obsolete" + '\n' + "Print",
 									obsoleteprint, CommandTypesEnum.kNonShapeEditCmdType, Globals.AddInClientId(),
+									StandardIcon: smallIcon, LargeIcon: largeIcon);
+								break;
+							}
+							case "Explode iComponents":
+							{
+								ExplodeiComponentsButton = controlDefs.AddButtonDefinition(
+									"Explode" + '\n' + "iComponents",
+									explodeicomponents, CommandTypesEnum.kShapeEditCmdType, Globals.AddInClientId(),
 									StandardIcon: smallIcon, LargeIcon: largeIcon);
 								break;
 							}
@@ -303,6 +328,16 @@ public class StandardAddInServer : ApplicationAddInServer
 		{
 			ObsoleteButton?.Delete();
 			ObsoleteButton = null;
+		}
+		catch
+		{
+			// ignored
+		}
+
+		try
+		{
+			ExplodeiComponentsButton?.Delete();
+			ExplodeiComponentsButton = null;
 		}
 		catch
 		{
@@ -474,6 +509,12 @@ public class StandardAddInServer : ApplicationAddInServer
 			Tuple.Create("id_TabTools", "userOptions", OptionsButton, ToolsOptions)
 		};
 
+		// ExplodeiComponents button - appears on Part documents
+		var explodeButtonConfigs = new List<Tuple<string, string, ButtonDefinition, string[]>>
+		{
+			Tuple.Create("id_TabManage", explodeicomponents, ExplodeiComponentsButton, ManagePanels)
+		};
+
 		// Obsolete Print button - only add if feature is enabled
 		var obsoletePrintConfigs = new List<Tuple<string, string, ButtonDefinition, string[]>>();
 		if (options.EnableObsoletePrint)
@@ -482,15 +523,11 @@ public class StandardAddInServer : ApplicationAddInServer
 		// Add buttons to appropriate ribbons based on document context
 		foreach (var (ribbonName, ribbon) in ribbonMappings)
 		{
-			// Add the DXF button only to Part ribbon
-			if (ribbonName == "Part")
-				foreach (var (tabName, panelName, buttonDef, fallbackPanels) in dxfButtonConfigs)
-					AddButtonToRibbon(ribbon, tabName, panelName, buttonDef, fallbackPanels);
 			AddButtonsToRibbon(ribbon, ribbonName, "Part", dxfButtonConfigs);
+			AddButtonsToRibbon(ribbon, ribbonName, null, optionsButtonConfigs);
 
-			// Add Options buttons to all ribbons
-			foreach (var (tabName, panelName, buttonDef, fallbackPanels) in optionsButtonConfigs)
-				AddButtonToRibbon(ribbon, tabName, panelName, buttonDef, fallbackPanels);
+			if (options.EnableExplodeiComponents)
+				AddButtonsToRibbon(ribbon, ribbonName, stringArray, explodeButtonConfigs);
 
 			if (options.EnableObsoletePrint)
 				AddButtonsToRibbon(ribbon, ribbonName, drawing, obsoletePrintConfigs);
@@ -620,6 +657,11 @@ public class StandardAddInServer : ApplicationAddInServer
 		new Action(() => ObsoletePrint.ApplyObsoletePrint(_application))();
 	}
 
+	private static void ExplodeiComponents_OnExecute()
+	{
+		ExplodeiComponents.ExplodeiComponentsAction();
+	}
+
 	// Helper method to refresh the ribbon UI
 	private void RefreshRibbon()
 	{
@@ -639,11 +681,10 @@ public class StandardAddInServer : ApplicationAddInServer
 	{
 		try
 		{
-			var ribbon = application.UserInterfaceManager.Ribbons[drawing];
-			if (ribbon is null) return;
 			var buttonRemovalConfigs = new[]
 			{
 				new { RibbonName = drawing, TabName = TabAnnotateId, ButtonInternalName = obsoleteprint },
+				new { RibbonName = drawing, TabName = TabAnnotateId, ButtonInternalName = explodeicomponents }
 			};
 
 			foreach (var config in buttonRemovalConfigs)


### PR DESCRIPTION
### Description

This pull request includes the following changes:

- **Explode iComponents feature**: Introduced functionality for processing iPart/iAssembly factories, creating Excel backups, generating standard components, and added ribbon button/user option toggles for user interaction.
- Simplified null check and invocation logic for `GetIPictureDispFromPicture` to improve code readability and maintainability.

### Checklist

- [ ] Code compiles without errors.
- [ ] Unit tests added or updated to match changes.
- [ ] Documentation updated where applicable.
- [ ] Tested feature functionality locally.