### PR TITLE
Refine version bump and release process

### DIFF
--- a/.github/workflows/dotnet-desktop.yml
+++ b/.github/workflows/dotnet-desktop.yml
@@ -1,20 +1,24 @@
 name: DoyleAddin - Version Bump + Release
-
 on:
   pull_request:
     types: [labeled, synchronize, closed]
     branches:
       - master
-
 jobs:
   version-bump:
     if: |
-      (github.event.action == 'labeled' && 
-       (github.event.label.name == 'major' || github.event.label.name == 'minor' || github.event.label.name == 'patch')) ||
-      (github.event.action == 'synchronize' && 
-       (contains(join(github.event.pull_request.labels.*.name, ','), 'major') ||
-        contains(join(github.event.pull_request.labels.*.name, ','), 'minor') ||
-        contains(join(github.event.pull_request.labels.*.name, ','), 'patch')))
+      (
+        (github.event.action == 'labeled' &&
+         (github.event.label.name == 'major' || github.event.label.name == 'minor' || github.event.label.name == 'patch') &&
+         github.event.label.name != 'no-release'
+        ) ||
+        (github.event.action == 'synchronize' &&
+         (contains(join(github.event.pull_request.labels.*.name, ','), 'major') ||
+          contains(join(github.event.pull_request.labels.*.name, ','), 'minor') ||
+          contains(join(github.event.pull_request.labels.*.name, ','), 'patch')) &&
+         !contains(join(github.event.pull_request.labels.*.name, ','), 'no-release')
+        )
+      )
     runs-on: windows-latest
     permissions:
       contents: write
@@ -25,31 +29,24 @@ jobs:
         with:
           ref: ${{ github.head_ref }}
           token: ${{ secrets.GITHUB_TOKEN }}
-
       - name: Bump version in csproj (on feature branch)
         shell: pwsh
         run: |
           $csprojPath = "Doyle Addin/DoyleAddin.csproj"
-
           [xml]$xml = Get-Content $csprojPath
           $currentVersionNode = $xml.Project.PropertyGroup | Where-Object { $_.FileVersion } | Select-Object -First 1
           $currentVersion = if ($currentVersionNode.FileVersion) { $currentVersionNode.FileVersion } else { "0.0.0.0" }
-
           $labels = '${{ toJson(github.event.pull_request.labels.*.name) }}' | ConvertFrom-Json
           $labelsLower = $labels | ForEach-Object { $_.ToLower() }
-
           $bumpType = "patch"
           if ($labelsLower -contains "major") { $bumpType = "major" }
           elseif ($labelsLower -contains "minor") { $bumpType = "minor" }
-
           Write-Host "Current: $currentVersion | Bump: $bumpType"
-
           if ($currentVersion -match '^(\d+)\.(\d+)\.(\d+)(?:\.(\d+))?') {
             $major = [int]$matches[1]
             $minor = [int]$matches[2]
             $patch = [int]$matches[3]
             $build = if ($matches[4]) { [int]$matches[4] } else { 0 }
-
             switch ($bumpType) {
               "major" { $major++; $minor=0; $patch=0; $build=0 }
               "minor" { $minor++; $patch=0; $build=0 }
@@ -59,21 +56,17 @@ jobs:
           } else {
             $newVersion = "0.0.0.0"
           }
-
           $fileNode = $xml.Project.PropertyGroup | Where-Object { $_.FileVersion } | Select-Object -First 1
-          $asmNode  = $xml.Project.PropertyGroup | Where-Object { $_.AssemblyVersion } | Select-Object -First 1
+          $asmNode = $xml.Project.PropertyGroup | Where-Object { $_.AssemblyVersion } | Select-Object -First 1
           if ($fileNode) { $fileNode.FileVersion = $newVersion }
-          if ($asmNode)  { $asmNode.AssemblyVersion = $newVersion }
+          if ($asmNode) { $asmNode.AssemblyVersion = $newVersion }
           $xml.Save($csprojPath)
-
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add $csprojPath
           git commit -m "chore: bump version to $newVersion (via PR label)" || echo "No changes"
           git push origin ${{ github.head_ref }}
-
           echo "NEW_VERSION=$newVersion" >> $env:GITHUB_ENV
-
       - name: Comment on PR
         uses: actions/github-script@v7
         with:
@@ -84,9 +77,8 @@ jobs:
               repo: context.repo.repo,
               body: `✅ Version automatically bumped to **${{ env.NEW_VERSION || 'N/A' }}** based on the PR label.`
             })
-
   release:
-    if: github.event.action == 'closed' && github.event.pull_request.merged == true
+    if: github.event.action == 'closed' && github.event.pull_request.merged == true && !contains(join(github.event.pull_request.labels.*.name, ','), 'no-release')
     runs-on: windows-latest
     permissions:
       contents: write
@@ -95,12 +87,10 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-
       - name: Setup .NET
         uses: actions/setup-dotnet@v4
         with:
           dotnet-version: '8.0.x'
-
       - name: Get current version from csproj
         id: version
         shell: pwsh
@@ -108,21 +98,19 @@ jobs:
           [xml]$xml = Get-Content "Doyle Addin/DoyleAddin.csproj"
           $ver = ($xml.Project.PropertyGroup | Where-Object { $_.FileVersion } | Select-Object -First 1).FileVersion
           echo "version=$ver" >> $env:GITHUB_OUTPUT
-
       - name: Publish
         run: |
           dotnet publish DoyleAddin.sln -c Release -o ./publish/DoyleAddin
-
       - name: Zip
         shell: pwsh
         run: |
           Compress-Archive -Path "./publish/DoyleAddin/*" -DestinationPath "DoyleAddin.zip" -Force
-
       - name: Create Release
         uses: softprops/action-gh-release@v2
         with:
           tag_name: v${{ steps.version.outputs.version }}
           name: Release v${{ steps.version.outputs.version }}
+          generate_release_notes: true
           files: |
             DoyleAddin.zip
             Doyle.Addin.Installer.bat


### PR DESCRIPTION
Updated version bump logic to exclude 'no-release' label and added release notes generation.